### PR TITLE
more parsing

### DIFF
--- a/internal/compiler/ast_microglot.go
+++ b/internal/compiler/ast_microglot.go
@@ -2,7 +2,14 @@ package compiler
 
 import (
 	"fmt"
+
+	"gopkg.microglot.org/compiler.go/internal/idl"
 )
+
+// interface for all AST nodes
+type node interface {
+	node()
+}
 
 // interface for all statement types
 type statement interface {
@@ -11,6 +18,7 @@ type statement interface {
 
 type ast struct {
 	comments   astCommentBlock
+	syntax     astStatementSyntax
 	statements []statement
 }
 
@@ -34,26 +42,60 @@ type astStatementModuleMeta struct {
 	comments              astCommentBlock
 }
 
-func (*astStatementSyntax) statement()     {}
-func (*astStatementModuleMeta) statement() {}
-
 type astAnnotationApplication struct {
-	// TODO 2023.08.16: incomplete
+	annotationInstances []astAnnotationInstance
+}
+
+type astAnnotationInstance struct {
+	namespace_identifier *idl.Token
+	identifier           idl.Token
+	value                astValue
 }
 
 type astTextLit struct {
-	value string
+	value idl.Token
 }
 
 type astIntLit struct {
-	strValue string
-	value    uint64
+	token idl.Token
+	value uint64
 }
 
 type astCommentBlock struct {
-	comments []astComment
+	comments []idl.Token
 }
 
-type astComment struct {
-	value string
+type astValue struct {
+	//TODO
 }
+
+type astValueUnary struct {
+	//TODO
+}
+
+type astValueBinary struct {
+	//TODO
+}
+
+type astValueIdentifier struct {
+	//TODO
+}
+
+type astValueLiteral struct {
+	//TODO
+}
+
+func (*ast) node()                    {}
+func (*astStatementSyntax) node()     {}
+func (*astStatementModuleMeta) node() {}
+func (*astAnnotationInstance) node()  {}
+func (*astTextLit) node()             {}
+func (*astIntLit) node()              {}
+func (*astCommentBlock) node()        {}
+func (*astValue) node()               {}
+func (*astValueUnary) node()          {}
+func (*astValueBinary) node()         {}
+func (*astValueIdentifier) node()     {}
+func (*astValueLiteral) node()        {}
+
+func (*astStatementModuleMeta) statement() {}

--- a/internal/compiler/parser_microglot_test.go
+++ b/internal/compiler/parser_microglot_test.go
@@ -13,24 +13,20 @@ import (
 
 func TestParser(t *testing.T) {
 	t.Parallel()
-
 	testCases := []struct {
 		name     string
 		input    string
-		expected *ast
+		parser   func(p *parserMicroglotTokens) node
+		expected node
 	}{
 		{
-			name:  "valid syntax statement",
-			input: "syntax = \"microglot0\"",
-			expected: &ast{
-				comments: astCommentBlock{
-					comments: []astComment{},
-				},
-				statements: []statement{
-					&astStatementSyntax{
-						syntax: astTextLit{
-							value: "microglot0",
-						},
+			name:   "valid syntax statement",
+			input:  "syntax = \"microglot0\"",
+			parser: func(p *parserMicroglotTokens) node { return p.parseStatementSyntax() },
+			expected: &astStatementSyntax{
+				syntax: astTextLit{
+					value: idl.Token{
+						Value: "microglot0",
 					},
 				},
 			},
@@ -38,50 +34,43 @@ func TestParser(t *testing.T) {
 		{
 			name:     "invalid syntax statement",
 			input:    "syntax lemon",
-			expected: nil,
+			parser:   func(p *parserMicroglotTokens) node { return p.parseStatementSyntax() },
+			expected: (*astStatementSyntax)(nil),
 		},
 		{
-			name:  "simple versioned module statement",
-			input: "module = @123",
-			expected: &ast{
+			name:   "simple versioned module statement",
+			input:  "module = @123",
+			parser: func(p *parserMicroglotTokens) node { return p.parseStatementModuleMeta() },
+			expected: &astStatementModuleMeta{
 				comments: astCommentBlock{
-					comments: []astComment{},
+					comments: nil,
 				},
-				statements: []statement{
-					&astStatementModuleMeta{
-						comments: astCommentBlock{
-							comments: []astComment{},
-						},
-						uid: astIntLit{
-							strValue: "123",
-							value:    123,
-						},
+				uid: astIntLit{
+					token: idl.Token{
+						Value: "123",
 					},
+					value: 123,
 				},
 			},
 		},
 		{
-			name:  "module with comment block",
-			input: "module = @123\n//comment\n//another\n",
-			expected: &ast{
-				comments: astCommentBlock{
-					comments: []astComment{},
+			name:   "module with comment block",
+			input:  "module = @123\n//comment\n//another\n",
+			parser: func(p *parserMicroglotTokens) node { return p.parseStatementModuleMeta() },
+			expected: &astStatementModuleMeta{
+				uid: astIntLit{
+					token: idl.Token{
+						Value: "123",
+					},
+					value: 123,
 				},
-				statements: []statement{
-					&astStatementModuleMeta{
-						uid: astIntLit{
-							strValue: "123",
-							value:    123,
+				comments: astCommentBlock{
+					comments: []idl.Token{
+						idl.Token{
+							Value: "comment",
 						},
-						comments: astCommentBlock{
-							comments: []astComment{
-								astComment{
-									value: "comment",
-								},
-								astComment{
-									value: "another",
-								},
-							},
+						idl.Token{
+							Value: "another",
 						},
 					},
 				},
@@ -90,18 +79,45 @@ func TestParser(t *testing.T) {
 		{
 			name:     "invalid module statement",
 			input:    "module lemon",
-			expected: nil,
+			parser:   func(p *parserMicroglotTokens) node { return p.parseStatementModuleMeta() },
+			expected: (*astStatementModuleMeta)(nil),
 		},
+		/*
+			{
+				name:   "non-namespaced annotation instance",
+				input:  "foo(1)",
+				parser: func(p *parserMicroglotTokens) node { return p.parseAnnotationInstance() },
+				expected: &astAnnotationInstance{
+					namespace_identifier: nil,
+					identifier: idl.Token{
+						Value: "foo",
+					},
+					value: astValue{},
+				},
+			},
+			{
+				name:   "namespaced annotation instance",
+				input:  "foo.bar(1)",
+				parser: func(p *parserMicroglotTokens) node { return p.parseAnnotationInstance() },
+				expected: &astAnnotationInstance{
+					namespace_identifier: &idl.Token{
+						Value: "foo",
+					},
+					identifier: idl.Token{
+						Value: "bar",
+					},
+					value: astValue{},
+				},
+			},
+		*/
 	}
 	for _, testCase := range testCases {
-		testCase := testCase
 		name := testCase.name
 		if name == "" {
 			name = testCase.input
 		}
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-
 			ctx := context.Background()
 			input := fs.NewFileString("/test", testCase.input, idl.FileKindMicroglot)
 			rep := exc.NewReporter(nil)
@@ -111,9 +127,9 @@ func TestParser(t *testing.T) {
 			lexerFile, err := lexer.Lex(ctx, input)
 			require.Nil(t, err)
 			parser := NewParserMicroglot(rep)
-			ast, err := parser.Parse(ctx, lexerFile)
+			p, err := parser.PrepareParse(ctx, lexerFile)
 			require.Nil(t, err)
-			require.Equal(t, testCase.expected, ast)
+			require.Equal(t, testCase.expected, testCase.parser(p))
 		})
 	}
 }

--- a/internal/compiler/subcompiler_microglot.go
+++ b/internal/compiler/subcompiler_microglot.go
@@ -34,10 +34,11 @@ func (self *SubCompilerMicroglot) CompileFile(ctx context.Context, r exc.Reporte
 		}
 		return nil, errors.New("aborting after dumping tokens, since the parser doesn't consume the token stream yet")
 	}
-	mod, err := parser.Parse(ctx, lf)
+	p, err := parser.PrepareParse(ctx, lf)
 	if err != nil {
 		return nil, err
 	}
+	mod := p.parse()
 	if dumpTree {
 		fmt.Println(mod)
 	}


### PR DESCRIPTION
The current state is somewhat awkward, because I'm halfway through implementing `Value` parsing. I commented out a couple of incomplete tests and marked the unfinished bits with //TODOs.

I've firmed up some of the patterns and naming, and tweaked the test harness to be able to test any `parse*` method.

I settled on:
 * `parse*` methods always expect*(), i.e. they're meant to be called when the parser believes that's what *should* be next.
   * therefore, branching/conditionality is always up to the parent method, using peek()
 * `expect*` methods always report and always advance, and always return `Token`
 
The only thing I'm still not entirely happy with is the pattern for branching parses, because it always duplicates the first token check (the parent does `peek()` and checks the type, then the child does `expect*()` of the same type). The only complication to cleaning up the duplication is error reporting; I'm thinking about that.