### PR TITLE
allow struct fields and virtual types to be API or SDK, but disallow transitively using API or SDK values as API method arguments.

### DIFF
--- a/internal/compiler/checker_test.go
+++ b/internal/compiler/checker_test.go
@@ -31,7 +31,7 @@ func TestChecker(t *testing.T) {
 				{
 					kind:     idl.FileKindMicroglot,
 					uri:      "/test.mgdl",
-					contents: `syntax = "microglot0"`,
+					contents: "syntax = \"microglot0\"\nmodule = @13",
 				},
 			},
 			expectCheckError: false,
@@ -42,7 +42,7 @@ func TestChecker(t *testing.T) {
 				{
 					kind:     idl.FileKindMicroglot,
 					uri:      "/test.mgdl",
-					contents: "syntax = \"microglot0\"\nstruct Foo { bar :Protobuf.Package }\n",
+					contents: "syntax = \"microglot0\"\nmodule = @13\nstruct Foo { bar :Protobuf.Package }\n",
 				},
 			},
 			expectCheckError: true,
@@ -53,7 +53,7 @@ func TestChecker(t *testing.T) {
 				{
 					kind:     idl.FileKindMicroglot,
 					uri:      "/test.mgdl",
-					contents: "syntax = \"microglot0\"\nconst Foo :Protobuf.Package = 1\n",
+					contents: "syntax = \"microglot0\"\nmodule = @13\nconst Foo :Protobuf.Package = 1\n",
 				},
 			},
 			expectCheckError: true,
@@ -65,7 +65,7 @@ func TestChecker(t *testing.T) {
 				{
 					kind:     idl.FileKindMicroglot,
 					uri:      "/test.mgdl",
-					contents: "syntax = \"microglot0\"\nconst Foo :Int32 = 32\nconst Bar :Int32 = Foo\nconst Baz :Int32 = -Bar\nconst Barney :Int32 = (Foo + Bar)\n",
+					contents: "syntax = \"microglot0\"\nmodule = @13\nconst Foo :Int32 = 32\nconst Bar :Int32 = Foo\nconst Baz :Int32 = -Bar\nconst Barney :Int32 = (Foo + Bar)\n",
 				},
 			},
 			expectCheckError: false,
@@ -76,7 +76,7 @@ func TestChecker(t *testing.T) {
 				{
 					kind:     idl.FileKindMicroglot,
 					uri:      "/test.mgdl",
-					contents: "syntax = \"microglot0\"\nstruct Foo { bar :Int32 = [] }\n",
+					contents: "syntax = \"microglot0\"\nmodule = @13\nstruct Foo { bar :Int32 = [] }\n",
 				},
 			},
 			expectCheckError: true,
@@ -87,7 +87,7 @@ func TestChecker(t *testing.T) {
 				{
 					kind:     idl.FileKindMicroglot,
 					uri:      "/test.mgdl",
-					contents: "syntax = \"microglot0\"\nannotation Foo(struct) :Text\nstruct Bar {} $(Foo([]))\n",
+					contents: "syntax = \"microglot0\"\nmodule = @13\nannotation Foo(struct) :Text\nstruct Bar {} $(Foo([]))\n",
 				},
 			},
 			expectCheckError: true,
@@ -99,7 +99,7 @@ func TestChecker(t *testing.T) {
 				{
 					kind:     idl.FileKindMicroglot,
 					uri:      "/test.mgdl",
-					contents: "syntax = \"microglot0\"\nstruct FooArgument { l :List<:Text> }\nannotation Foo(struct) :FooArgument\nstruct Bar {} $(Foo({l: []}))\n",
+					contents: "syntax = \"microglot0\"\nmodule = @13\nstruct FooArgument { l :List<:Text> }\nannotation Foo(struct) :FooArgument\nstruct Bar {} $(Foo({l: []}))\n",
 				},
 			},
 			expectCheckError: false,
@@ -110,7 +110,7 @@ func TestChecker(t *testing.T) {
 				{
 					kind:     idl.FileKindMicroglot,
 					uri:      "/test.mgdl",
-					contents: "syntax = \"microglot0\"\nstruct FooArgument { l :List<:Text> }\nannotation Foo(struct) :FooArgument\nstruct Bar {} $(Foo({l: 32}))\n",
+					contents: "syntax = \"microglot0\"\nmodule = @13\nstruct FooArgument { l :List<:Text> }\nannotation Foo(struct) :FooArgument\nstruct Bar {} $(Foo({l: 32}))\n",
 				},
 			},
 			expectCheckError: true,
@@ -121,7 +121,7 @@ func TestChecker(t *testing.T) {
 				{
 					kind:     idl.FileKindMicroglot,
 					uri:      "/test.mgdl",
-					contents: "syntax = \"microglot0\"\nstruct FooArgument { l :List<:Text> }\nannotation Foo(struct) :FooArgument\nstruct Bar {} $(Foo({l: [32]}))\n",
+					contents: "syntax = \"microglot0\"\nmodule = @13\nstruct FooArgument { l :List<:Text> }\nannotation Foo(struct) :FooArgument\nstruct Bar {} $(Foo({l: [32]}))\n",
 				},
 			},
 			expectCheckError: true,
@@ -133,7 +133,7 @@ func TestChecker(t *testing.T) {
 				{
 					kind:     idl.FileKindMicroglot,
 					uri:      "/test.mgdl",
-					contents: "syntax = \"microglot0\"\nstruct FooArgument { p :Presence<:Text> }\nannotation Foo(struct) :FooArgument\nstruct Bar {} $(Foo({p: \"present\"}))\n",
+					contents: "syntax = \"microglot0\"\nmodule = @13\nstruct FooArgument { p :Presence<:Text> }\nannotation Foo(struct) :FooArgument\nstruct Bar {} $(Foo({p: \"present\"}))\n",
 				},
 			},
 			expectCheckError: false,
@@ -144,7 +144,7 @@ func TestChecker(t *testing.T) {
 				{
 					kind:     idl.FileKindMicroglot,
 					uri:      "/test.mgdl",
-					contents: "syntax = \"microglot0\"\nstruct FooArgument { p :Presence<:Text> }\nannotation Foo(struct) :FooArgument\nstruct Bar {} $(Foo({}))\n",
+					contents: "syntax = \"microglot0\"\nmodule = @13\nstruct FooArgument { p :Presence<:Text> }\nannotation Foo(struct) :FooArgument\nstruct Bar {} $(Foo({}))\n",
 				},
 			},
 			expectCheckError: false,
@@ -155,7 +155,7 @@ func TestChecker(t *testing.T) {
 				{
 					kind:     idl.FileKindMicroglot,
 					uri:      "/test.mgdl",
-					contents: "syntax = \"microglot0\"\nstruct FooArgument { p :Presence<:Text> }\nannotation Foo(struct) :FooArgument\nstruct Bar {} $(Foo({p: 32}))\n",
+					contents: "syntax = \"microglot0\"\nmodule = @13\nstruct FooArgument { p :Presence<:Text> }\nannotation Foo(struct) :FooArgument\nstruct Bar {} $(Foo({p: 32}))\n",
 				},
 			},
 			expectCheckError: true,
@@ -167,7 +167,7 @@ func TestChecker(t *testing.T) {
 				{
 					kind:     idl.FileKindMicroglot,
 					uri:      "/test.mgdl",
-					contents: "syntax = \"microglot0\"\nstruct Foo { bar :Text }\nannotation Bar(struct) :Foo\nstruct Baz {} $(Bar({ bar: \"ASDF\" }))\n",
+					contents: "syntax = \"microglot0\"\nmodule = @13\nstruct Foo { bar :Text }\nannotation Bar(struct) :Foo\nstruct Baz {} $(Bar({ bar: \"ASDF\" }))\n",
 				},
 			},
 			expectCheckError: false,
@@ -178,7 +178,7 @@ func TestChecker(t *testing.T) {
 				{
 					kind:     idl.FileKindMicroglot,
 					uri:      "/test.mgdl",
-					contents: "syntax = \"microglot0\"\nstruct Foo { bar :Text }\nannotation Bar(struct) :Foo\nstruct Baz {} $(Bar({ }))\n",
+					contents: "syntax = \"microglot0\"\nmodule = @13\nstruct Foo { bar :Text }\nannotation Bar(struct) :Foo\nstruct Baz {} $(Bar({ }))\n",
 				},
 			},
 			expectCheckError: false,
@@ -189,7 +189,7 @@ func TestChecker(t *testing.T) {
 				{
 					kind:     idl.FileKindMicroglot,
 					uri:      "/test.mgdl",
-					contents: "syntax = \"microglot0\"\nstruct Foo { bar :Text }\nannotation Bar(struct) :Foo\nstruct Baz {} $(Bar({ barney: \"ASDF\", bar: \"ASDF\" }))\n",
+					contents: "syntax = \"microglot0\"\nmodule = @13\nstruct Foo { bar :Text }\nannotation Bar(struct) :Foo\nstruct Baz {} $(Bar({ barney: \"ASDF\", bar: \"ASDF\" }))\n",
 				},
 			},
 			expectCheckError: true,
@@ -200,7 +200,40 @@ func TestChecker(t *testing.T) {
 				{
 					kind:     idl.FileKindMicroglot,
 					uri:      "/test.mgdl",
-					contents: "syntax = \"microglot0\"\nstruct Foo { bar :Text }\nannotation Bar(struct) :Foo\nstruct Baz {} $(Bar({ bar: 99 }))\n",
+					contents: "syntax = \"microglot0\"\nmodule = @13\nstruct Foo { bar :Text }\nannotation Bar(struct) :Foo\nstruct Baz {} $(Bar({ bar: 99 }))\n",
+				},
+			},
+			expectCheckError: true,
+		},
+		{
+			name: "structs as api method input/output",
+			files: []CheckerTestFile{
+				{
+					kind:     idl.FileKindMicroglot,
+					uri:      "/test.mgdl",
+					contents: "syntax = \"microglot0\"\nmodule = @13\nstruct In {}\nstruct Out {}\napi Foo { Method(:In) returns (:Out) }",
+				},
+			},
+			expectCheckError: false,
+		},
+		{
+			name: "structs as api method input/output (transitive SDK in input)",
+			files: []CheckerTestFile{
+				{
+					kind:     idl.FileKindMicroglot,
+					uri:      "/test.mgdl",
+					contents: "syntax = \"microglot0\"\nmodule = @13\nsdk Nope {}\nstruct In { X :List<:Nope> }\nstruct Out {}\napi Foo { Method(:In) returns (:Out) }",
+				},
+			},
+			expectCheckError: true,
+		},
+		{
+			name: "structs as api method input/output (transitive API in output)",
+			files: []CheckerTestFile{
+				{
+					kind:     idl.FileKindMicroglot,
+					uri:      "/test.mgdl",
+					contents: "syntax = \"microglot0\"\nmodule = @13\napi Nope {}\nstruct In {}\nstruct Out { X :List<:Nope> }\napi Foo { Method(:In) returns (:Out) }",
 				},
 			},
 			expectCheckError: true,

--- a/internal/compiler/linker_microglot_test.go
+++ b/internal/compiler/linker_microglot_test.go
@@ -32,7 +32,7 @@ func TestLinker(t *testing.T) {
 				{
 					kind:               idl.FileKindMicroglot,
 					uri:                "/test.mgdl",
-					contents:           `syntax = "microglot0"`,
+					contents:           "syntax = \"microglot0\"\nmodule = @13",
 					expectCollectError: false,
 					expectLinkError:    false,
 				},
@@ -44,7 +44,7 @@ func TestLinker(t *testing.T) {
 				{
 					kind:               idl.FileKindMicroglot,
 					uri:                "/test.mgdl",
-					contents:           "syntax = \"microglot0\"\nconst foo :Bool = true",
+					contents:           "syntax = \"microglot0\"\nmodule = @13\nconst foo :Bool = true",
 					expectCollectError: false,
 					expectLinkError:    false,
 				},
@@ -56,7 +56,7 @@ func TestLinker(t *testing.T) {
 				{
 					kind:               idl.FileKindMicroglot,
 					uri:                "/test.mgdl",
-					contents:           "syntax = \"microglot0\"\nconst foo :Bool = true\nconst foo :String = \"asdf\"\n",
+					contents:           "syntax = \"microglot0\"\nmodule = @13\nconst foo :Bool = true\nconst foo :String = \"asdf\"\n",
 					expectCollectError: true,
 					expectLinkError:    false,
 				},
@@ -87,7 +87,7 @@ func TestLinker(t *testing.T) {
 				{
 					kind:               idl.FileKindMicroglot,
 					uri:                "/test.mgdl",
-					contents:           "syntax = \"microglot0\"\nconst boo :Boolean = bar",
+					contents:           "syntax = \"microglot0\"\nmodule = @13\nconst boo :Boolean = bar",
 					expectCollectError: false,
 					expectLinkError:    true,
 				},
@@ -99,7 +99,7 @@ func TestLinker(t *testing.T) {
 				{
 					kind:               idl.FileKindMicroglot,
 					uri:                "/test.mgdl",
-					contents:           "syntax = \"microglot0\"\nimport \"/nonexistent.mgdl\" as n",
+					contents:           "syntax = \"microglot0\"\nmodule = @13\nimport \"/nonexistent.mgdl\" as n",
 					expectCollectError: false,
 					expectLinkError:    true,
 				},
@@ -130,7 +130,7 @@ func TestLinker(t *testing.T) {
 				{
 					kind:               idl.FileKindMicroglot,
 					uri:                "/test.mgdl",
-					contents:           "syntax = \"microglot0\"\nconst x :Bool = true @10\nconst y :Bool = false @10",
+					contents:           "syntax = \"microglot0\"\nmodule = @13\nconst x :Bool = true @10\nconst y :Bool = false @10",
 					expectCollectError: true,
 					expectLinkError:    false,
 				},
@@ -142,7 +142,7 @@ func TestLinker(t *testing.T) {
 				{
 					kind:               idl.FileKindMicroglot,
 					uri:                "/test.mgdl",
-					contents:           "syntax = \"microglot0\"\nconst x :Bool = true\nconst y :Bool = x",
+					contents:           "syntax = \"microglot0\"\nmodule = @13\nconst x :Bool = true\nconst y :Bool = x",
 					expectCollectError: false,
 					expectLinkError:    false,
 				},
@@ -154,7 +154,7 @@ func TestLinker(t *testing.T) {
 				{
 					kind:               idl.FileKindMicroglot,
 					uri:                "/test.mgdl",
-					contents:           "syntax = \"microglot0\"\nconst y :Bool = x",
+					contents:           "syntax = \"microglot0\"\nmodule = @13\nconst y :Bool = x",
 					expectCollectError: false,
 					expectLinkError:    true,
 				},
@@ -166,7 +166,7 @@ func TestLinker(t *testing.T) {
 				{
 					kind:               idl.FileKindMicroglot,
 					uri:                "/test.mgdl",
-					contents:           "syntax = \"microglot0\"\nenum x { y }\nconst z :Bool = x.y",
+					contents:           "syntax = \"microglot0\"\nmodule = @13\nenum x { y }\nconst z :Bool = x.y",
 					expectCollectError: false,
 					expectLinkError:    false,
 				},
@@ -178,7 +178,7 @@ func TestLinker(t *testing.T) {
 				{
 					kind:               idl.FileKindMicroglot,
 					uri:                "/test.mgdl",
-					contents:           "syntax = \"microglot0\"\nenum x { y }\nconst z :Bool = x.a",
+					contents:           "syntax = \"microglot0\"\nmodule = @13\nenum x { y }\nconst z :Bool = x.a",
 					expectCollectError: false,
 					expectLinkError:    true,
 				},
@@ -209,7 +209,7 @@ func TestLinker(t *testing.T) {
 				{
 					kind:               idl.FileKindMicroglot,
 					uri:                "/test.mgdl",
-					contents:           "syntax = \"microglot0\"\nimport \"/test.proto\" as p\nconst z :p.Foo = 0",
+					contents:           "syntax = \"microglot0\"\nmodule = @13\nimport \"/test.proto\" as p\nconst z :p.Foo = 0",
 					expectCollectError: false,
 					expectLinkError:    false,
 				},
@@ -221,7 +221,7 @@ func TestLinker(t *testing.T) {
 				{
 					kind:               idl.FileKindMicroglot,
 					uri:                "/test.mgdl",
-					contents:           "syntax = \"microglot0\"\nstruct Foo {}",
+					contents:           "syntax = \"microglot0\"\nmodule = @13\nstruct Foo {}",
 					expectCollectError: false,
 					expectLinkError:    false,
 				},
@@ -277,9 +277,13 @@ func TestLinker(t *testing.T) {
 			}
 
 			symbols := globalSymbolTable{}
-			completedDescriptors := make([]*proto.Module, 0, len(parsedDescriptors))
+			protobufDescriptor = completeUIDs(*protobufDescriptor)
 			err = symbols.collect(*protobufDescriptor, r)
 			require.NoError(t, err, "/protobuf.mgdl", r.Reported())
+			protobufDescriptor, err = link(*protobufDescriptor, &symbols, r)
+			require.NoError(t, err, "/protobuf.mgdl", r.Reported())
+
+			completedDescriptors := make([]*proto.Module, 0, len(parsedDescriptors))
 			for i, parsedDescriptor := range parsedDescriptors {
 				completedDescriptor := completeUIDs(*parsedDescriptor)
 				err := symbols.collect(*completedDescriptor, r)

--- a/internal/idl/convert.go
+++ b/internal/idl/convert.go
@@ -406,7 +406,7 @@ func (c *imageConverter) fromResolvedReference(resolvedReference *proto.Resolved
 			label := descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL
 			return &label, type_, typeName, nil
 		default:
-			return nil, nil, nil, fmt.Errorf("built-in type %s doesn't convert to protobuf", builtinTypeName)
+			return nil, nil, nil, fmt.Errorf("built-in type %v doesn't convert to protobuf", builtinTypeName)
 		}
 	}
 


### PR DESCRIPTION
As discussed!