### PR TITLE
Fix protobuf plugin error reporting

### DIFF
--- a/main.go
+++ b/main.go
@@ -162,7 +162,7 @@ func main() {
 		}
 
 		if response.Error != nil {
-			fmt.Fprintln(os.Stderr, response.Error)
+			fmt.Fprintln(os.Stderr, response.GetError())
 			os.Exit(1)
 		}
 


### PR DESCRIPTION
The error value returned from a plugin response is actually a string pointer so printing it directly just shows the address. Using `GetError()` should safely convert it to a non-pointer.