### PR TITLE
Make all qualified names begin with dot

### DIFF
--- a/internal/idl/convert.go
+++ b/internal/idl/convert.go
@@ -144,7 +144,7 @@ func (c *imageConverter) getQualifiedName(protobufPackage string, moduleUID uint
 	if nestedName != name {
 		return nestedName
 	}
-	return fmt.Sprintf("%s.%s", protobufPackage, name)
+	return fmt.Sprintf(".%s.%s", protobufPackage, name)
 }
 
 func (c *imageConverter) fromModule(module *proto.Module) (*descriptorpb.FileDescriptorProto, error) {


### PR DESCRIPTION
Twirp is one of my target pb plugins for APIs. I found that it uses the string value of the input and output names as map keys in some places. It failed to generate because it expects the service method InputType and OutputType names to be dot prefixed in addition to including the package name.

The descriptor.proto spec says that these values may be fully qualified or they may need to be resolved so this would appear to be a bug with Twirp not implementing the correct resolution. However, the fact that it works with normal protobuf means that protoc is likely always setting the fields to fully qualified paths.

From what I can tell, none of the other plugins I'm using have this issue and work just fine with or without the dot prefix.