### PR TITLE
Generate attribute UIDs in the protobuf range 

### DIFF
--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -298,6 +298,17 @@ func newUID(parentUID uint64, name string) uint64 {
 	}
 	return typeUID
 }
+func newAttributeUID(parent uint64, name string) uint64 {
+	// Protubuf field numbers are limited to 2^29 - 1 because the first three
+	// bytes are used to encode the field type. For compatibility we must remove
+	// the leading three bits.
+	//
+	// TODO 2024.02.01: Attribute UID values must also not be in the range of
+	//                  19000 - 19999. Add a check that validates all field UID
+	//                  values are in the supported range.
+	uid := newUID(parent, name)
+	return uid & 0x1FFFFFFF
+}
 
 func completeTypeReference(moduleUID uint64, name string, typeReference *proto.TypeReference) {
 	if typeReference.ModuleUID == idl.Incomplete {
@@ -327,7 +338,7 @@ func completeAttributeReference(moduleUID uint64, typeUID uint64, name string, a
 	}
 
 	if attributeReference.AttributeUID == idl.Incomplete {
-		attributeReference.AttributeUID = newUID(typeUID, name)
+		attributeReference.AttributeUID = newAttributeUID(typeUID, name)
 	}
 
 }
@@ -354,7 +365,7 @@ func completeSDKInputReference(moduleUID uint64, typeUID uint64, attributeUID ui
 		panic(fmt.Errorf("the attribute UID for %s is already set, which shouldn't happen", name))
 	}
 
-	if sdkInputReference.AttributeUID == idl.Incomplete {
+	if sdkInputReference.InputUID == idl.Incomplete {
 		sdkInputReference.InputUID = newUID(attributeUID, name)
 	}
 }

--- a/internal/idl/convert.go
+++ b/internal/idl/convert.go
@@ -348,8 +348,7 @@ func (c *imageConverter) fromUnion(union *proto.Union) (*descriptorpb.OneofDescr
 }
 
 func (c *imageConverter) fromField(field *proto.Field) (*descriptorpb.FieldDescriptorProto, error) {
-	number := (int32)(field.Reference.AttributeUID)
-
+	number := int32(field.Reference.AttributeUID)
 	label, type_, typeName, err := c.fromTypeSpecifier(field.Type, &field.Name)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
~~This patch isn't to merge, it's more of an example of a problem.~~

Protobuf limits field numbers to the range of 1 - 2^29-1 and 19000 - 19999 are reserved for internal use. Some cases of auto-generated field UIDs cannot be safely converted to protobuf. I ran into a failure case using this:
```
syntax = "microglot0"

module = @0xA $(
    Protobuf.FileOptionsGoPackage("foo/foo;foo")
)

struct Bar {
    List :List<:Text>
    Map :Map<:Text, :Text>
}
```
It fails because the generated UID for `Map`  becomes `-795744862` when down sized to int32. Running absolute value on the number still fails because it's too large. A combination of bit masking the first 3 bytes, absolute value, and shifting out of the reserved range should make the number values safe enough to use.

This issue only surfaces when writing new microglot IDL that does not have user-defined UID values. All protobuf source requires user-defined field numbers for every field and within the valid range so all protobuf numbers safely convert to microglot field UIDs. User-defined UID values in microglot will have a natural bias to small numbers so it's unlikely someone would unintentionally choose a field UID that is outside the protobuf range or even within the 19k-19999 range, really. This is an artifact of the synthetic UID generation which biases towards large numbers.

The code in this patch should safely convert all field UIDs from microglot to protobuf. However, this brings up a new challenge. Masking and shifting are lossy operations in the sense that the resulting protobuf field number can not be converted back to the full uint64 or reliably matched against a subset of the original bytes. This isn't something I accounted for in the spec and I believe this will cause issues later on with native features. Two solutions come to find first. One is that the descriptor can track two fields: `AttributeUID` and `AttributeProtoNumber`. The `AttributeProtoNumber` would be the masked and shifted version. Future code would only use the proto number when dealing with protobuf encoding. Another option is to impose the same constraints as protobuf on the first version of microglot. The actual type can remain uint64 but valid values would be constrained to less than 536,870,911 and not in the 19k-19999 range.

I'm slightly partial to the second option. Half a billion fields sounds... reasonably large. I wanted to see if you can think of any other alternatives, though. In the meantime, it's an easy workaround to just add UID values for fields.
