### PR TITLE
Always copy struct name value when converting

### DIFF
--- a/internal/idl/convert.go
+++ b/internal/idl/convert.go
@@ -326,8 +326,13 @@ func (c *imageConverter) fromStruct(struct_ *proto.Struct) (*descriptorpb.Descri
 		}
 	}
 
+	name := new(string)
+	*name = struct_.Name.Name
+	// TODO: 2024.02.01: Audit the code for pointer passing like this. Replace
+	//                   them with a helper that always generates a pointer to
+	//                   a copy.
 	return &descriptorpb.DescriptorProto{
-		Name:       &struct_.Name.Name,
+		Name:       name,
 		Field:      fields,
 		OneofDecl:  oneofs,
 		Options:    options,


### PR DESCRIPTION
This one had me scratching my head for a moment. The conversion code reconstructs the original nested type structure using the annotations. This works as expected. However, the code recursively calls `fromStruct` on the nested types and then modifies the name to match the original instead of the "promoted" name. Passing a pointer to the original string
from the microglot descriptor was resulting in the microglot descriptor being modified when the converted proto descriptor was modified. 