### PR TITLE
Allow conflicting enumerants from mgdl

### DIFF
--- a/internal/idl/protobuf.go
+++ b/internal/idl/protobuf.go
@@ -10,6 +10,7 @@ var PROTOBUF_TYPE_UIDS = map[string]uint64{
 	"FileOptionsGoPackage": 3,
 	"JsonName":             4,
 	"Proto3Optional":       5,
+	"EnumFromProto":        6,
 }
 
 var PROTOBUF_IDL = fmt.Sprintf(`
@@ -31,9 +32,11 @@ annotation NestedTypeInfo(struct, enum) :NestedTypes @%d
 annotation FileOptionsGoPackage(module) :Text @%d
 annotation JsonName(field) :Text @%d
 annotation Proto3Optional(field) :Bool @%d
+annotation EnumFromProto(enum) :Bool @%d
 `, PROTOBUF_TYPE_UIDS["Package"],
 	PROTOBUF_TYPE_UIDS["NestedTypeInfo"],
 	PROTOBUF_TYPE_UIDS["FileOptionsGoPackage"],
 	PROTOBUF_TYPE_UIDS["JsonName"],
 	PROTOBUF_TYPE_UIDS["Proto3Optional"],
+	PROTOBUF_TYPE_UIDS["EnumFromProto"],
 )


### PR DESCRIPTION
This PR is just me thinking out loud about this problem. I have it in my notes to revise the spec and include something about enum name conflicts so I assume we've talked about this before. I finally hit the issue while working on a project.

In protobuf, enumerant names must be unique within the package. They aren't encapsulated by the enum except when they are generated to code. There's a few related github issues and the official response seems to be that enums are designed with C symbol scoping in mind. The end result seems to be that protobuf enumerants are really more like named int32 constants than they are like what most would consider an enumerant because the enum doesn't encapsulate them. TIL that protobuf enumerant UID values can be negative as a reflection of them actually being named constants.

This came up because I have an IDL file with a few different enums that each defined the zero value as `Invalid @0` which caused protoc-gen-go to throw it back due to a naming conflict. Then I realized that the default zero value of `None @0` also causes the naming conflict. You currently cannot define two enums in the same module unless you redefine the zero value to ensure they do not match and also use only mutually exclusive names for enumerants.

This patch is a quick hack to see what would happen if all microglot defined enums were automatically prefixed when converting to protobuf. It works but the output is ugly because protoc-gen-go already prefixes the rendered enumerants. So `enum Foo { None @0 }` becomes `Foo_Foo_None`. At the same time, it's effectively required practice in protobuf to either prefix enumerant names or nest enums within another type (thus prefixing the name) in order to deal with name conflicts. So `enum Foo { FOO_None = 0 }` isn't necessarily uncommon for protobuf users and it renders to `Foo_FOO_None`. I don't work with protobuf enums that often so maybe this is actually standard fare and nobody would notice?

This current draft adds an option to all protobuf sourced enums to identify them as originating from protobuf so that they are not auto-prefixed. It then prefixes every enumerant not identified as coming from protobuf when converting to protobuf.