### PR TITLE
Fix nil pointer reference for proto enum handling

### DIFF
--- a/internal/compiler/protobuf/descriptor.go
+++ b/internal/compiler/protobuf/descriptor.go
@@ -665,7 +665,7 @@ func (c *fileDescriptorConverter) fromEnumDescriptorProto(enumDescriptor *descri
 func (c *fileDescriptorConverter) fromEnumValueDescriptorProto(enumValueDescriptor *descriptorpb.EnumValueDescriptorProto) (*proto.Enumerant, error) {
 	// TODO 2023.10.10: convert Options
 	name := *enumValueDescriptor.Name
-	trueName, ok := getUnregisteredOption("MicroglotName", enumValueDescriptor.Options.UninterpretedOption)
+	trueName, ok := getUnregisteredOption("MicroglotName", enumValueDescriptor.GetOptions().GetUninterpretedOption())
 	if ok {
 		name = trueName
 	}


### PR DESCRIPTION
Enums defined in protobuf and without the true name annotations were causing nil pointer exceptions. Using the proto field getters resolves this.